### PR TITLE
FIX: mount to a dom variable doesn't work

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -572,6 +572,8 @@ class SakanaWidget {
     let _el: HTMLElement | null = null;
     if (typeof el === 'string') {
       _el = document.querySelector(el);
+    } else {
+      _el = el;
     }
     if (!_el) {
       throw new Error('Invalid mounting element');


### PR DESCRIPTION
If param `el` is a `HtmlElement`, `_el` will always be null.